### PR TITLE
Improve connect handling

### DIFF
--- a/mod_authn_dovecot.c
+++ b/mod_authn_dovecot.c
@@ -132,6 +132,19 @@ static authn_status check_password(request_rec * r, const char *user, const char
 	struct timeval tv;
 	struct connection_state cs;
 
+	size_t authsocklen = strlen(conf->dovecotauthsocket);
+	if (authsocklen >= sizeof address.sun_path) {
+		// Note: Some OS support longer sun_path via the "struct hack".
+		// Not Linux.  See:
+		// https://mail-index.netbsd.org/tech-net/2006/10/11/0008.html
+		ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Dovecot Authentication: dovecot socket path %s is too long.", conf->dovecotauthsocket);
+		if (conf->authoritative == 0) {
+			return DECLINED;
+		} else {
+			return AUTH_USER_NOT_FOUND;
+		}
+	}
+
 	apr_pool_create(&p, r->pool);	// create subpool for local functions, variables...
 
 	// setting default values for connection state 
@@ -155,7 +168,7 @@ static authn_status check_password(request_rec * r, const char *user, const char
 		perror("fcntl(F_SETFL)");
 	}
 	address.sun_family = AF_UNIX;
-	strncpy(address.sun_path,conf->dovecotauthsocket, strlen(conf->dovecotauthsocket));
+	memcpy(address.sun_path, conf->dovecotauthsocket, authsocklen + 1);
 	result = connect(auths, (struct sockaddr *)&address, sizeof address);
 	if (result) {
 		ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Dovecot Authentication: could not connect to dovecot socket %s: %s", address.sun_path, strerror(errno));

--- a/mod_authn_dovecot.c
+++ b/mod_authn_dovecot.c
@@ -27,6 +27,7 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "apr_base64.h"		// base64 encode
 
@@ -157,7 +158,7 @@ static authn_status check_password(request_rec * r, const char *user, const char
 	strncpy(address.sun_path,conf->dovecotauthsocket, strlen(conf->dovecotauthsocket));
 	result = connect(auths, (struct sockaddr *)&address, sizeof address);
 	if (result) {
-		ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Dovecot Authentication: could not connect to dovecot socket");
+		ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Dovecot Authentication: could not connect to dovecot socket %s: %s", address.sun_path, strerror(errno));
 		if (conf->authoritative == 0) {
 			return DECLINED;
 		} else {
@@ -186,7 +187,7 @@ static authn_status check_password(request_rec * r, const char *user, const char
 
 		readsocks = select(fdmax + 1, &socks_r, &socks_w, NULL, &tv);
 		if (readsocks < 0) {
-			ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Dovecot Authentication: socket select");
+			ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Dovecot Authentication: socket select: %s", strerror(errno));
 			return DECLINED;
 		}
 

--- a/mod_authn_dovecot.c
+++ b/mod_authn_dovecot.c
@@ -25,6 +25,7 @@
 #include "http_request.h"
 #include "mod_auth.h"
 
+#include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <string.h>
@@ -170,7 +171,7 @@ static authn_status check_password(request_rec * r, const char *user, const char
 	address.sun_family = AF_UNIX;
 	memcpy(address.sun_path, conf->dovecotauthsocket, authsocklen + 1);
 	result = connect(auths, (struct sockaddr *)&address, sizeof address);
-	if (result) {
+	if (result && errno != EINPROGRESS) {
 		ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "Dovecot Authentication: could not connect to dovecot socket %s: %s", address.sun_path, strerror(errno));
 		if (conf->authoritative == 0) {
 			return DECLINED;


### PR DESCRIPTION
After upgrading to apache2 version 2.4.25-3+deb9u5 on Debian stretch, authentication started failing with `Dovecot Authentication: could not connect to dovecot socket` when using the `http2` module.  The problem was ultimately due to lack of null-termination of `sun_path` in `struct sockaddr_un`.  This PR includes a fix for that issue and a few additional fixes and improvements I made while testing:

* Ensure `sun_path` is null-terminated.  The previous code did not copy the terminating null byte, which would cause connection failure when `strlen(conf->dovecotauthsocket) < sizeof(sun_path)` and `sun_path` happened to contain non-`'\0'` after the end of the copied bytes.
* Avoid overflowing `sun_path` when `conf->dovecotauthsocket` is longer than `sizeof(sun_path)`.  Instead, log an error and exit early.
* Handle asynchronous connections via `EINPROGRESS`.
* Include system error message and socket path in logged errors to aid debugging.

If you'd like me to split either of those commits into separate PRs, let me know.

Thanks,
Kevin