### PR TITLE
Token user=... ends the line.

### DIFF
--- a/mod_authn_dovecot.c
+++ b/mod_authn_dovecot.c
@@ -367,7 +367,7 @@ int receive_data(apr_pool_t * p, request_rec * r, struct connection_state *cs, c
 		cs->authenticated = 1;
 		apr_strtok(data, "\t", &last);
 		apr_strtok(NULL, "\t", &last);
-		user = apr_strtok(NULL, "\t", &last); /* "OK" */
+		user = apr_strtok(NULL, "\n", &last); /* "OK" */
 		next = apr_strtok(NULL, "\t", &last); /* "1" */
 		if (user != NULL &&
 			(next == NULL || (next - user) >


### PR DESCRIPTION
The dovecot auth daemon answers an AUTH request with "OK ... user=... <NEWLINE>". If tokenizing on "\t" for the last field the user variable will contain the line break and thus the REMOTE_USER variable will also. This is, for example bad for RewriteRules that use %{LA-U:REMOTE_USER} or CGI/PHP scripts that use this variable.

Tokenizing the last field on "\n" instead fixes this.